### PR TITLE
Fix settings type import and version script guard

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Editor, MarkdownView, Modal, Notice, Plugin, PluginSettingTab, Setting } from 'obsidian';
+import { App, Editor, MarkdownView, Modal, Notice, Plugin, PluginSettingTab, Setting, TextComponent } from 'obsidian';
 
 // Remember to rename these classes and interfaces!
 
@@ -123,12 +123,12 @@ class SampleSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName('Setting #1')
 			.setDesc('It\'s a secret')
-			.addText(text => text
-				.setPlaceholder('Enter your secret')
-				.setValue(this.plugin.settings.mySetting)
-				.onChange(async (value) => {
-					this.plugin.settings.mySetting = value;
-					await this.plugin.saveSettings();
-				}));
+                        .addText((text: TextComponent) => text
+                                .setPlaceholder('Enter your secret')
+                                .setValue(this.plugin.settings.mySetting)
+                                .onChange(async (value: string) => {
+                                        this.plugin.settings.mySetting = value;
+                                        await this.plugin.saveSettings();
+                                }));
 	}
 }

--- a/version-bump.mjs
+++ b/version-bump.mjs
@@ -1,6 +1,9 @@
 import { readFileSync, writeFileSync } from "fs";
 
 const targetVersion = process.env.npm_package_version;
+if (!targetVersion) {
+    throw new Error("npm_package_version is not defined");
+}
 
 // read minAppVersion from manifest.json and bump version to target version
 let manifest = JSON.parse(readFileSync("manifest.json", "utf8"));


### PR DESCRIPTION
## Summary
- add missing `TextComponent` import and types for settings handler
- validate required env var in `version-bump` script

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68486ff56654832faa68b08732b38006