### PR TITLE
Fix documentation bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This sample plugin demonstrates some of the basic functionality the plugin API c
 - Adds a ribbon icon, which shows a Notice when clicked.
 - Adds a command "Open Sample Modal" which opens a Modal.
 - Adds a plugin setting tab to the settings page.
-- Registers a global click event and output 'click' to the console.
+- Registers a global click event and outputs 'click' to the console.
 - Registers a global interval which logs 'setInterval' to the console.
 
 ## First time developing plugins?


### PR DESCRIPTION
## Summary
- fix wording of click event bullet in README

## Testing
- `npm run build` *(fails: Property addStatusBarItem does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6848750c80f4832fa9b7221fc0a043df