### PR TITLE
Fix license mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	},
 	"keywords": [],
 	"author": "",
-	"license": "MIT",
+        "license": "ISC",
 	"devDependencies": {
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "5.29.0",


### PR DESCRIPTION
## Summary
- set `package.json` license to ISC to match LICENSE file

## Testing
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684875089378832fad36392ab1815ae0