### PR TITLE
Add docs generation npm script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ data.json
 
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
+docs/

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Quick starting guide for new plugin devs:
 - After installing dependencies you can run the test suite with:
   - `npm test`
 
+## Generate documentation (optional)
+- [TypeDoc](https://typedoc.org/) can create HTML documentation from your TypeScript source.
+- After installing dependencies run:
+  - `npm run docs`
 
 ## Funding URL
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"obsidian": "latest",
 				"ts-jest": "^29.1.1",
 				"tslib": "2.4.0",
+				"typedoc": "^0.25.2",
 				"typescript": "4.7.4"
 			}
 		},
@@ -2074,6 +2075,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/ansi-sequence-parser": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.3.tgz",
+			"integrity": "sha512-+fksAx9eG3Ab6LDnLs3ZqZa8KVJ/jYnX+D4Qe1azX+LFGFAXqynCQLOdLpNYN/l9e7l6hMWwZbrnctqr6eSQSw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
@@ -4372,6 +4380,13 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/jsonc-parser": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4463,6 +4478,13 @@
 				"yallist": "^3.0.2"
 			}
 		},
+		"node_modules/lunr": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/make-dir": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -4494,6 +4516,19 @@
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"tmpl": "1.0.5"
+			}
+		},
+		"node_modules/marked": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/merge-stream": {
@@ -5172,6 +5207,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/shiki": {
+			"version": "0.14.7",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+			"integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-sequence-parser": "^1.1.0",
+				"jsonc-parser": "^3.2.0",
+				"vscode-oniguruma": "^1.7.0",
+				"vscode-textmate": "^8.0.0"
+			}
+		},
 		"node_modules/signal-exit": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -5527,6 +5575,54 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/typedoc": {
+			"version": "0.25.13",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.13.tgz",
+			"integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"lunr": "^2.3.9",
+				"marked": "^4.3.0",
+				"minimatch": "^9.0.3",
+				"shiki": "^0.14.7"
+			},
+			"bin": {
+				"typedoc": "bin/typedoc"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"peerDependencies": {
+				"typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
+			}
+		},
+		"node_modules/typedoc/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/typedoc/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "4.7.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
@@ -5596,6 +5692,20 @@
 			"engines": {
 				"node": ">=10.12.0"
 			}
+		},
+		"node_modules/vscode-oniguruma": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+			"integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vscode-textmate": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+			"integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/w3c-keyname": {
 			"version": "2.2.8",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
                 "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
                 "version": "node version-bump.mjs && git add manifest.json versions.json",
                 "lint": "eslint . --ext .ts",
+                "docs": "typedoc",
                 "test": "jest"
         },
 	"keywords": [],
@@ -25,6 +26,7 @@
                 "eslint": "^8.44.0",
                 "jest": "^29.7.0",
                 "ts-jest": "^29.1.1",
-                "@types/jest": "^29.5.6"
+                "@types/jest": "^29.5.6",
+                "typedoc": "^0.25.2"
        }
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "entryPoints": ["src"],
+  "entryPointStrategy": "expand",
+  "out": "docs"
+}


### PR DESCRIPTION
## Summary
- add lint and docs script to package.json
- include typedoc dev dependency and config
- ignore generated docs in git
- document docs script in README
- update lockfile with typedoc packages

## Testing
- `npm test`
- `npm run docs`


------
https://chatgpt.com/codex/tasks/task_e_68489f8449f8832f960ff90d1e01eea0