### PR TITLE
Configure repository URL for typedoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,32 +1,36 @@
 {
-	"name": "obsidian-sample-plugin",
-	"version": "1.0.0",
-	"description": "This is a sample plugin for Obsidian (https://obsidian.md)",
-	"main": "main.js",
-        "scripts": {
-                "dev": "node esbuild.config.mjs",
-                "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-                "version": "node version-bump.mjs && git add manifest.json versions.json",
-                "lint": "eslint . --ext .ts",
-                "docs": "typedoc",
-                "test": "jest"
-        },
-	"keywords": [],
-	"author": "",
-        "license": "ISC",
-	"devDependencies": {
-		"@types/node": "^16.11.6",
-		"@typescript-eslint/eslint-plugin": "5.29.0",
-		"@typescript-eslint/parser": "5.29.0",
-		"builtin-modules": "3.3.0",
-                "esbuild": "^0.25.5",
-		"obsidian": "latest",
-		"tslib": "2.4.0",
-                "typescript": "4.7.4",
-                "eslint": "^8.44.0",
-                "jest": "^29.7.0",
-                "ts-jest": "^29.1.1",
-                "@types/jest": "^29.5.6",
-                "typedoc": "^0.25.2"
-       }
+  "name": "obsidian-sample-plugin",
+  "version": "1.0.0",
+  "description": "This is a sample plugin for Obsidian (https://obsidian.md)",
+  "main": "main.js",
+  "scripts": {
+    "dev": "node esbuild.config.mjs",
+    "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+    "version": "node version-bump.mjs && git add manifest.json versions.json",
+    "lint": "eslint . --ext .ts",
+    "docs": "typedoc",
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/node": "^16.11.6",
+    "@typescript-eslint/eslint-plugin": "5.29.0",
+    "@typescript-eslint/parser": "5.29.0",
+    "builtin-modules": "3.3.0",
+    "esbuild": "^0.25.5",
+    "obsidian": "latest",
+    "tslib": "2.4.0",
+    "typescript": "4.7.4",
+    "eslint": "^8.44.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.6",
+    "typedoc": "^0.25.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/obsidianmd/obsidian-sample-plugin.git"
+  }
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,8 @@
 {
-  "entryPoints": ["src"],
+  "entryPoints": [
+    "src"
+  ],
   "entryPointStrategy": "expand",
-  "out": "docs"
+  "out": "docs",
+  "gitRevision": "main"
 }


### PR DESCRIPTION
## Summary
- set the GitHub repository in `package.json`
- document git revision in `typedoc.json`

## Testing
- `npm run docs`

------
https://chatgpt.com/codex/tasks/task_e_6848a45ed710832fa5b2e356e55b763e