### PR TITLE
Enable esModuleInterop

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "importHelpers": true,
     "isolatedModules": true,
     "strictNullChecks": true,
+    "esModuleInterop": true,
     "lib": [
       "DOM",
       "ES5",


### PR DESCRIPTION
## Summary
- enable `esModuleInterop` in TypeScript options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848a639f274832f8f89a46f18d461a3