### PR TITLE
Update CI for Node.js 22

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -26,6 +26,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+        cache-dependency-path: package-lock.json
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test


### PR DESCRIPTION
## Summary
- run CI with Node 22 only
- specify `package-lock.json` for setup-node caching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848a714c100832f8d5f9297e22b23b4