### PR TITLE
Add Lumi side panel

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -83,6 +83,7 @@ export default class LoomNotesCompanion extends Plugin {
       return;
     }
     const leaf = this.app.workspace.getRightLeaf(false);
+    if (!leaf) return;
     await leaf.setViewState({ type: VIEW_TYPE_LUMI, active: true });
     this.app.workspace.revealLeaf(leaf);
   }

--- a/src/lumiPanel.ts
+++ b/src/lumiPanel.ts
@@ -16,7 +16,7 @@ export class LumiPanel extends ItemView {
     return 'Lumi';
   }
 
-  onOpen(): void {
+  async onOpen(): Promise<void> {
     const container = this.containerEl.children[1];
     container.empty();
     const active = this.app.workspace.getActiveViewOfType(MarkdownView);
@@ -34,7 +34,7 @@ export class LumiPanel extends ItemView {
     };
   }
 
-  onClose(): void {
+  async onClose(): Promise<void> {
     const container = this.containerEl.children[1];
     container.empty();
   }

--- a/src/lumiPanel.ts
+++ b/src/lumiPanel.ts
@@ -1,0 +1,41 @@
+import { ItemView, WorkspaceLeaf, MarkdownView } from 'obsidian';
+import { drawCards } from './oracle';
+
+export const VIEW_TYPE_LUMI = 'lumi-panel';
+
+export class LumiPanel extends ItemView {
+  constructor(leaf: WorkspaceLeaf) {
+    super(leaf);
+  }
+
+  getViewType(): string {
+    return VIEW_TYPE_LUMI;
+  }
+
+  getDisplayText(): string {
+    return 'Lumi';
+  }
+
+  onOpen(): void {
+    const container = this.containerEl.children[1];
+    container.empty();
+    const active = this.app.workspace.getActiveViewOfType(MarkdownView);
+    const text = active?.editor.getValue() || '';
+    const words = text.split(/\s+/).filter(Boolean).length;
+    container.createEl('h2', { text: 'Olá, eu sou Lumi ✨' });
+    container.createEl('p', { text: `Sua nota possui ${words} palavras.` });
+    const button = container.createEl('button', { text: 'Sortear Carta' });
+    button.onclick = () => {
+      container.empty();
+      const [card] = drawCards(1);
+      container.createEl('h2', { text: card.title });
+      container.createEl('p', { text: card.description });
+      container.createEl('em', { text: card.prompt });
+    };
+  }
+
+  onClose(): void {
+    const container = this.containerEl.children[1];
+    container.empty();
+  }
+}


### PR DESCRIPTION
## Summary
- implement a Lumi side panel view mirroring modal conversation UI
- register the new view and toggle command with `Ctrl+Shift+L`
- detach open panels on unload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848d22c046c832fa7844bdc20242eb2