### PR TITLE
Add Templater integration

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -10,6 +10,7 @@ import {
 import { LumiModal } from './src/lumiModal';
 import { drawCards } from './src/oracle';
 import { LumiPanel, VIEW_TYPE_LUMI } from './src/lumiPanel';
+import { isTemplaterEnabled, showTemplatePicker } from './src/templaterHelper';
 
 interface LoomNotesSettings {
   dailyFolder: string;
@@ -73,6 +74,9 @@ export default class LoomNotesCompanion extends Plugin {
     }
     const leaf = this.app.workspace.getLeaf(true);
     await leaf.openFile(file);
+    if (isTemplaterEnabled(this.app)) {
+      showTemplatePicker(this.app);
+    }
     new LumiModal(this.app).open();
   }
 

--- a/src/templaterHelper.ts
+++ b/src/templaterHelper.ts
@@ -7,12 +7,12 @@ export interface TemplaterPlugin {
 }
 
 export function getTemplaterPlugin(app: App): TemplaterPlugin | null {
-  const plugin = app.plugins.getPlugin('templater-obsidian');
-  return plugin as unknown as TemplaterPlugin | null;
+  const plugin = (app as any).plugins?.getPlugin?.('templater-obsidian');
+  return plugin ? (plugin as unknown as TemplaterPlugin) : null;
 }
 
 export function isTemplaterEnabled(app: App): boolean {
-  return getTemplaterPlugin(app) !== null && getTemplaterPlugin(app) !== undefined;
+  return getTemplaterPlugin(app) != null;
 }
 
 export function showTemplatePicker(app: App): boolean {

--- a/src/templaterHelper.ts
+++ b/src/templaterHelper.ts
@@ -1,0 +1,25 @@
+import { App } from 'obsidian';
+
+export interface TemplaterPlugin {
+  fuzzy_suggester?: {
+    insert_template: () => void;
+  };
+}
+
+export function getTemplaterPlugin(app: App): TemplaterPlugin | null {
+  const plugin = app.plugins.getPlugin('templater-obsidian');
+  return plugin as unknown as TemplaterPlugin | null;
+}
+
+export function isTemplaterEnabled(app: App): boolean {
+  return getTemplaterPlugin(app) !== null && getTemplaterPlugin(app) !== undefined;
+}
+
+export function showTemplatePicker(app: App): boolean {
+  const tpl = getTemplaterPlugin(app);
+  if (tpl && tpl.fuzzy_suggester?.insert_template) {
+    tpl.fuzzy_suggester.insert_template();
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- hook into Templater when creating daily notes
- add helper module to detect Templater and show template chooser

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848d67286ac832f83cff5ec2d1dea11