### PR TITLE
Add reflection and project setup commands

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -11,6 +11,8 @@ import { LumiModal } from './src/lumiModal';
 import { drawCards } from './src/oracle';
 import { LumiPanel, VIEW_TYPE_LUMI } from './src/lumiPanel';
 import { isTemplaterEnabled, showTemplatePicker } from './src/templaterHelper';
+import { openReflection } from './src/reflection';
+import { promptAndStartProject } from './src/project';
 
 interface LoomNotesSettings {
   dailyFolder: string;
@@ -59,6 +61,18 @@ export default class LoomNotesCompanion extends Plugin {
       id: 'loomnotes-start-day',
       name: 'LoomNotes: Iniciar Dia',
       callback: () => this.startDay(),
+    });
+
+    this.addCommand({
+      id: 'loomnotes-open-reflection',
+      name: 'LoomNotes: Abrir Reflexão',
+      callback: () => openReflection(this.app),
+    });
+
+    this.addCommand({
+      id: 'loomnotes-start-project',
+      name: 'LoomNotes: Iniciar Projeto',
+      callback: () => promptAndStartProject(this.app),
     });
 
     this.addSettingTab(new LoomNotesSettingTab(this.app, this));

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,0 +1,25 @@
+import { App, TFile } from 'obsidian';
+
+export async function startProject(app: App, name: string, baseFolder = 'Projetos'): Promise<TFile | null> {
+  if (!name) return null;
+  const folderPath = `${baseFolder}/${name}`;
+  try {
+    await app.vault.adapter.mkdir(folderPath);
+  } catch (e) {
+    // ignore if folder exists
+  }
+  const path = `${folderPath}/index.md`;
+  let file = app.vault.getAbstractFileByPath(path) as TFile;
+  if (!file) {
+    file = await app.vault.create(path, `# ${name}\n\nDescreva o objetivo do projeto.\n`);
+  }
+  const leaf = app.workspace.getLeaf(true);
+  await leaf.openFile(file);
+  return file;
+}
+
+export async function promptAndStartProject(app: App, baseFolder = 'Projetos'): Promise<TFile | null> {
+  const name = window.prompt('Nome do projeto');
+  if (!name) return null;
+  return startProject(app, name, baseFolder);
+}

--- a/src/reflection.ts
+++ b/src/reflection.ts
@@ -1,0 +1,13 @@
+import { App, TFile } from 'obsidian';
+
+export async function openReflection(app: App, folder = 'Reflexoes'): Promise<TFile> {
+  const date = window.moment().format('YYYY-MM-DD');
+  const path = `${folder}/${date}.md`;
+  let file = app.vault.getAbstractFileByPath(path) as TFile;
+  if (!file) {
+    file = await app.vault.create(path, `# ${date}\n\nComo você se sente hoje?\n`);
+  }
+  const leaf = app.workspace.getLeaf(true);
+  await leaf.openFile(file);
+  return file;
+}


### PR DESCRIPTION
## Summary
- open reflection notes through a new command
- add project starter command with folder creation
- implement logic in new `reflection` and `project` modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848d8221088832f86a018ae9072343d