### PR TITLE
Add Iconize integration for folder icons

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -13,6 +13,7 @@ import { LumiPanel, VIEW_TYPE_LUMI } from './src/lumiPanel';
 import { isTemplaterEnabled, showTemplatePicker } from './src/templaterHelper';
 import { openReflection } from './src/reflection';
 import { promptAndStartProject } from './src/project';
+import { updateIcons } from './src/iconize';
 
 interface LoomNotesSettings {
   dailyFolder: string;
@@ -86,6 +87,7 @@ export default class LoomNotesCompanion extends Plugin {
     if (!file) {
       file = await this.app.vault.create(path, `# ${date}\n\nComo você se sente hoje?\n`);
     }
+    updateIcons(this.app, { [folder]: 'calendar' });
     const leaf = this.app.workspace.getLeaf(true);
     await leaf.openFile(file);
     if (isTemplaterEnabled(this.app)) {

--- a/src/iconize.ts
+++ b/src/iconize.ts
@@ -1,0 +1,24 @@
+import { App } from 'obsidian';
+
+export interface IconizePlugin {
+  addFolderIcon?: (path: string, icon: string) => void;
+}
+
+export function getIconizePlugin(app: App): IconizePlugin | null {
+  const plugin =
+    (app as any).plugins?.getPlugin?.('icon-folder') ??
+    (app as any).plugins?.getPlugin?.('obsidian-icon-folder');
+  return plugin ? (plugin as unknown as IconizePlugin) : null;
+}
+
+export function updateIcons(app: App, folders: Record<string, string>): void {
+  const iconize = getIconizePlugin(app);
+  if (!iconize?.addFolderIcon) return;
+  for (const [path, icon] of Object.entries(folders)) {
+    try {
+      iconize.addFolderIcon(path, icon);
+    } catch {
+      // ignore errors from iconize
+    }
+  }
+}

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,4 +1,5 @@
 import { App, TFile } from 'obsidian';
+import { updateIcons } from './iconize';
 
 export async function startProject(app: App, name: string, baseFolder = 'Projetos'): Promise<TFile | null> {
   if (!name) return null;
@@ -8,6 +9,7 @@ export async function startProject(app: App, name: string, baseFolder = 'Projeto
   } catch (e) {
     // ignore if folder exists
   }
+  updateIcons(app, { [baseFolder]: 'folder', [folderPath]: 'folder' });
   const path = `${folderPath}/index.md`;
   let file = app.vault.getAbstractFileByPath(path) as TFile;
   if (!file) {


### PR DESCRIPTION
## Summary
- detect Iconize plugin via new helper
- assign icons to folders on daily/project creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848d918a6f8832f9e2885b7d5bae318