### PR TITLE
Add custom oracle deck support

### DIFF
--- a/src/lumiModal.ts
+++ b/src/lumiModal.ts
@@ -1,9 +1,11 @@
 import { App, Modal, MarkdownView } from 'obsidian';
-import { drawCards } from './oracle';
+import { drawCards, OracleCard, defaultDeck } from './oracle';
 
 export class LumiModal extends Modal {
-  constructor(app: App) {
+  deck: OracleCard[];
+  constructor(app: App, deck: OracleCard[] = defaultDeck) {
     super(app);
+    this.deck = deck;
   }
 
   onOpen(): void {
@@ -16,7 +18,7 @@ export class LumiModal extends Modal {
     const button = contentEl.createEl('button', { text: 'Sortear Carta' });
     button.onclick = () => {
       contentEl.empty();
-      const [card] = drawCards(1);
+      const [card] = drawCards(1, this.deck);
       contentEl.createEl('h2', { text: card.title });
       contentEl.createEl('p', { text: card.description });
       contentEl.createEl('em', { text: card.prompt });

--- a/src/lumiPanel.ts
+++ b/src/lumiPanel.ts
@@ -1,11 +1,13 @@
 import { ItemView, WorkspaceLeaf, MarkdownView } from 'obsidian';
-import { drawCards } from './oracle';
+import { drawCards, OracleCard, defaultDeck } from './oracle';
 
 export const VIEW_TYPE_LUMI = 'lumi-panel';
 
 export class LumiPanel extends ItemView {
-  constructor(leaf: WorkspaceLeaf) {
+  deck: OracleCard[];
+  constructor(leaf: WorkspaceLeaf, deck: OracleCard[] = defaultDeck) {
     super(leaf);
+    this.deck = deck;
   }
 
   getViewType(): string {
@@ -27,7 +29,7 @@ export class LumiPanel extends ItemView {
     const button = container.createEl('button', { text: 'Sortear Carta' });
     button.onclick = () => {
       container.empty();
-      const [card] = drawCards(1);
+      const [card] = drawCards(1, this.deck);
       container.createEl('h2', { text: card.title });
       container.createEl('p', { text: card.description });
       container.createEl('em', { text: card.prompt });

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -4,3 +4,12 @@ test('draw card from default deck', () => {
   const [card] = drawCards(1);
   expect(defaultDeck).toContainEqual(card);
 });
+
+test('draw card from custom deck', () => {
+  const custom = [
+    { title: 'A', description: 'B', prompt: 'C' },
+    { title: 'D', description: 'E', prompt: 'F' },
+  ];
+  const [card] = drawCards(1, custom);
+  expect(custom).toContainEqual(card);
+});

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,0 +1,34 @@
+jest.mock('obsidian', () => ({
+  Plugin: class {},
+  PluginSettingTab: class {},
+  Modal: class {},
+  ItemView: class {},
+  WorkspaceLeaf: class {},
+  App: class {},
+  MarkdownView: class {},
+  Notice: class {},
+  Setting: class {
+    setName() { return this; }
+    setDesc() { return this; }
+    addText() { return this; }
+    addTextArea() { return this; }
+  },
+  TFile: class {},
+}), { virtual: true });
+
+import LoomNotesCompanion from '../main';
+import { OracleCard } from '../src/oracle';
+
+class TestPlugin extends LoomNotesCompanion {
+  constructor() {
+    super({} as any, {} as any);
+  }
+}
+
+test('loadSettings parses custom deck JSON', async () => {
+  const deck: OracleCard[] = [{ title: 'X', description: 'Y', prompt: 'Z' }];
+  const plugin = new TestPlugin();
+  plugin.loadData = jest.fn().mockResolvedValue({ deckJSON: JSON.stringify(deck) });
+  await plugin.loadSettings();
+  expect(plugin.deck).toEqual(deck);
+});


### PR DESCRIPTION
## Summary
- allow specifying a custom deck JSON in settings
- load custom decks on plugin start
- use custom deck when drawing cards
- update settings UI for deck JSON
- test custom deck loading and drawing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848da608bc8832fae8b82653d2f910d