### PR TITLE
Add folder creation to openReflection

### DIFF
--- a/src/reflection.ts
+++ b/src/reflection.ts
@@ -3,6 +3,13 @@ import { App, TFile } from 'obsidian';
 export async function openReflection(app: App, folder = 'Reflexoes'): Promise<TFile> {
   const date = window.moment().format('YYYY-MM-DD');
   const path = `${folder}/${date}.md`;
+  if (!app.vault.getAbstractFileByPath(folder)) {
+    try {
+      await app.vault.createFolder(folder);
+    } catch {
+      // ignore folder creation errors
+    }
+  }
   let file = app.vault.getAbstractFileByPath(path) as TFile;
   if (!file) {
     file = await app.vault.create(path, `# ${date}\n\nComo você se sente hoje?\n`);

--- a/tests/openReflection.test.ts
+++ b/tests/openReflection.test.ts
@@ -1,0 +1,58 @@
+jest.mock('obsidian', () => ({
+  App: class {},
+  TFile: class {},
+}), { virtual: true });
+
+import { openReflection } from '../src/reflection';
+
+describe('openReflection', () => {
+  beforeEach(() => {
+    (global as any).window = {
+      moment: jest.fn(() => ({ format: () => '2024-01-01' })),
+    };
+  });
+
+  afterEach(() => {
+    delete (global as any).window;
+  });
+
+  test('creates folder when missing', async () => {
+    const createFolder = jest.fn().mockResolvedValue(undefined);
+    const create = jest.fn().mockResolvedValue({});
+    const getAbstractFileByPath = jest
+      .fn()
+      .mockReturnValueOnce(null) // folder check
+      .mockReturnValueOnce(null); // file check
+    const openFile = jest.fn();
+    const app = {
+      vault: { getAbstractFileByPath, create, createFolder },
+      workspace: { getLeaf: jest.fn().mockReturnValue({ openFile }) },
+    } as any;
+
+    await openReflection(app);
+
+    expect(createFolder).toHaveBeenCalledWith('Reflexoes');
+    expect(create).toHaveBeenCalled();
+    expect(openFile).toHaveBeenCalled();
+  });
+
+  test('ignores folder creation errors', async () => {
+    const createFolder = jest.fn().mockRejectedValue(new Error('fail'));
+    const create = jest.fn().mockResolvedValue({});
+    const getAbstractFileByPath = jest
+      .fn()
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(null);
+    const openFile = jest.fn();
+    const app = {
+      vault: { getAbstractFileByPath, create, createFolder },
+      workspace: { getLeaf: jest.fn().mockReturnValue({ openFile }) },
+    } as any;
+
+    await openReflection(app);
+
+    expect(createFolder).toHaveBeenCalled();
+    expect(create).toHaveBeenCalled();
+    expect(openFile).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `openReflection` creates the reflections folder if missing
- test folder creation logic and error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848e00236cc832f83590c2484922775