### PR TITLE
Add startDay and command registration tests

### DIFF
--- a/tests/commandRegistration.test.ts
+++ b/tests/commandRegistration.test.ts
@@ -1,0 +1,74 @@
+import LoomNotesCompanion from '../main';
+
+jest.mock('../src/lumiModal', () => ({
+  __esModule: true,
+  LumiModal: jest.fn().mockImplementation(() => ({ open: jest.fn() })),
+}));
+
+jest.mock('../src/lumiPanel', () => ({
+  VIEW_TYPE_LUMI: 'lumi-panel',
+  LumiPanel: jest.fn(),
+}));
+
+jest.mock('../src/iconize', () => ({
+  updateIcons: jest.fn(),
+}));
+
+jest.mock('../src/templaterHelper', () => ({
+  isTemplaterEnabled: jest.fn(),
+  showTemplatePicker: jest.fn(),
+}));
+
+jest.mock('../src/reflection', () => ({
+  openReflection: jest.fn(),
+}));
+
+jest.mock('../src/project', () => ({
+  promptAndStartProject: jest.fn(),
+}));
+
+jest.mock('obsidian', () => ({
+  Plugin: class {},
+  PluginSettingTab: class {},
+  Modal: class {},
+  ItemView: class {},
+  WorkspaceLeaf: class {},
+  App: class {},
+  MarkdownView: class {},
+  Notice: class {},
+  Setting: class {
+    setName() { return this; }
+    setDesc() { return this; }
+    addText() { return this; }
+    addTextArea() { return this; }
+  },
+  TFile: class {},
+}), { virtual: true });
+
+describe('command registration', () => {
+  class TestPlugin extends LoomNotesCompanion {
+    constructor(app: any) {
+      super({} as any, {} as any);
+      this.app = app as any;
+    }
+  }
+
+  test('loomnotes-start-day command triggers startDay', async () => {
+    const plugin = new TestPlugin({});
+    plugin.addCommand = jest.fn();
+    plugin.registerView = jest.fn();
+    plugin.addSettingTab = jest.fn();
+    plugin.loadSettings = jest.fn();
+
+    await plugin.onload();
+
+    const call = (plugin.addCommand as jest.Mock).mock.calls.find(
+      ([cmd]) => cmd.id === 'loomnotes-start-day'
+    );
+    expect(call).toBeDefined();
+
+    plugin.startDay = jest.fn();
+    call[0].callback();
+    expect(plugin.startDay).toHaveBeenCalled();
+  });
+});

--- a/tests/commandRegistration.test.ts
+++ b/tests/commandRegistration.test.ts
@@ -1,4 +1,3 @@
-import LoomNotesCompanion from '../main';
 
 jest.mock('../src/lumiModal', () => ({
   __esModule: true,
@@ -44,6 +43,8 @@ jest.mock('obsidian', () => ({
   },
   TFile: class {},
 }), { virtual: true });
+
+const LoomNotesCompanion = require('../main').default;
 
 describe('command registration', () => {
   class TestPlugin extends LoomNotesCompanion {

--- a/tests/startDay.test.ts
+++ b/tests/startDay.test.ts
@@ -1,4 +1,3 @@
-import LoomNotesCompanion from '../main';
 import { LumiModal } from '../src/lumiModal';
 import { updateIcons } from '../src/iconize';
 import { isTemplaterEnabled, showTemplatePicker } from '../src/templaterHelper';
@@ -34,6 +33,8 @@ jest.mock('obsidian', () => ({
   },
   TFile: class {},
 }), { virtual: true });
+
+const LoomNotesCompanion = require('../main').default;
 
 describe('startDay', () => {
   const date = '2024-01-01';

--- a/tests/startDay.test.ts
+++ b/tests/startDay.test.ts
@@ -1,4 +1,7 @@
 import LoomNotesCompanion from '../main';
+import { LumiModal } from '../src/lumiModal';
+import { updateIcons } from '../src/iconize';
+import { isTemplaterEnabled, showTemplatePicker } from '../src/templaterHelper';
 
 jest.mock('../src/lumiModal', () => ({
   __esModule: true,
@@ -10,7 +13,7 @@ jest.mock('../src/iconize', () => ({
 }));
 
 jest.mock('../src/templaterHelper', () => ({
-  isTemplaterEnabled: () => false,
+  isTemplaterEnabled: jest.fn(),
   showTemplatePicker: jest.fn(),
 }));
 
@@ -78,5 +81,33 @@ describe('startDay', () => {
 
     await expect(plugin.startDay()).resolves.not.toThrow();
     expect(create).toHaveBeenCalled();
+  });
+
+  test('opens file and shows template when templater enabled', async () => {
+    (isTemplaterEnabled as jest.Mock).mockReturnValue(true);
+    const createFolder = jest.fn().mockResolvedValue(undefined);
+    const create = jest.fn().mockResolvedValue({});
+    const getAbstractFileByPath = jest
+      .fn()
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(null);
+    const openFile = jest.fn();
+    const plugin = new TestPlugin({
+      vault: { getAbstractFileByPath, createFolder, create },
+      workspace: { getLeaf: jest.fn(() => ({ openFile })) },
+    });
+    plugin.settings = { dailyFolder: 'Diario', deckJSON: '' } as any;
+
+    await plugin.startDay();
+
+    expect(create).toHaveBeenCalledWith(
+      `Diario/${date}.md`,
+      expect.stringContaining(`# ${date}`)
+    );
+    expect(openFile).toHaveBeenCalled();
+    expect(updateIcons).toHaveBeenCalledWith(plugin.app, { Diario: 'calendar' });
+    expect(showTemplatePicker).toHaveBeenCalledWith(plugin.app);
+    const modal = (LumiModal as jest.Mock).mock.results[0].value;
+    expect(modal.open).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- expand startDay unit test with templater and modal flow
- add command registration test verifying loomnotes-start-day command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848e0b89c2c832f8ea59be7e5dee175