### PR TITLE
Ensure reflection folder creation

### DIFF
--- a/src/reflection.ts
+++ b/src/reflection.ts
@@ -3,7 +3,8 @@ import { App, TFile } from 'obsidian';
 export async function openReflection(app: App, folder = 'Reflexoes'): Promise<TFile> {
   const date = window.moment().format('YYYY-MM-DD');
   const path = `${folder}/${date}.md`;
-  if (!app.vault.getAbstractFileByPath(folder)) {
+  const folderExists = app.vault.getAbstractFileByPath(folder);
+  if (!folderExists) {
     try {
       await app.vault.createFolder(folder);
     } catch {

--- a/tests/openReflection.test.ts
+++ b/tests/openReflection.test.ts
@@ -55,4 +55,24 @@ describe('openReflection', () => {
     expect(create).toHaveBeenCalled();
     expect(openFile).toHaveBeenCalled();
   });
+
+  test('skips folder creation when folder already exists', async () => {
+    const createFolder = jest.fn();
+    const create = jest.fn().mockResolvedValue({});
+    const getAbstractFileByPath = jest
+      .fn()
+      .mockReturnValueOnce({}) // folder exists
+      .mockReturnValueOnce(null); // file check
+    const openFile = jest.fn();
+    const app = {
+      vault: { getAbstractFileByPath, create, createFolder },
+      workspace: { getLeaf: jest.fn().mockReturnValue({ openFile }) },
+    } as any;
+
+    await openReflection(app);
+
+    expect(createFolder).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalled();
+    expect(openFile).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- verify existence of the reflection folder before creating it
- extend tests for `openReflection` to cover existing folder scenario

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848e2aa371c832fa19c1208f9600c10