### PR TITLE
Update version workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ your theme to customize the appearance.
 
 Install dependencies with `npm i` and start the watcher with `npm run dev`. Run the test suite with `npm test`.
 
+To release a new version run `npm version <patch|minor|major>`. This command
+updates `package.json` and executes `version-bump.mjs`, which copies the version
+to `manifest.json` and records it in `versions.json`. Inspect those files or run
+`git diff HEAD` to verify the changes. Push the resulting commit and tag with
+`git push --follow-tags`, ensuring `versions.json` is included in the release.
+
 ## API Documentation
 
 See [Obsidian API](https://github.com/obsidianmd/obsidian-api).


### PR DESCRIPTION
## Summary
- mention npm version and automatic manifest bump
- add check for version-bump.mjs results
- call out versions.json needs to be included in each release tag

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ea489098832fb02939d762f17cc1