### PR TITLE
Fix build failures by excluding tests

### DIFF
--- a/tests/commandRegistration.test.ts
+++ b/tests/commandRegistration.test.ts
@@ -44,7 +44,7 @@ jest.mock('obsidian', () => ({
   TFile: class {},
 }), { virtual: true });
 
-const LoomNotesCompanion = require('../main').default;
+import LoomNotesCompanion from '../main.ts';
 
 describe('command registration', () => {
   class TestPlugin extends LoomNotesCompanion {

--- a/tests/startDay.test.ts
+++ b/tests/startDay.test.ts
@@ -34,7 +34,7 @@ jest.mock('obsidian', () => ({
   TFile: class {},
 }), { virtual: true });
 
-const LoomNotesCompanion = require('../main').default;
+import LoomNotesCompanion from '../main.ts';
 
 describe('startDay', () => {
   const date = '2024-01-01';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,10 @@
     ]
   },
   "include": [
-    "**/*.ts"
+    "main.ts",
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "tests"
   ]
 }


### PR DESCRIPTION
## Summary
- exclude test files from `tsconfig.json`
- import the TypeScript entry explicitly in test files

## Testing
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848ee847a18832facb66c5c37e0edef