### PR TITLE
Fix project folder check

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -4,10 +4,12 @@ import { updateIcons } from './iconize';
 export async function startProject(app: App, name: string, baseFolder = 'Projetos'): Promise<TFile | null> {
   if (!name) return null;
   const folderPath = `${baseFolder}/${name}`;
-  try {
-    await app.vault.adapter.mkdir(folderPath);
-  } catch (e) {
-    // ignore if folder exists
+  if (!app.vault.getAbstractFileByPath(folderPath)) {
+    try {
+      await app.vault.createFolder(folderPath);
+    } catch (e) {
+      // ignore if folder exists or cannot be created
+    }
   }
   updateIcons(app, { [baseFolder]: 'folder', [folderPath]: 'folder' });
   const path = `${folderPath}/index.md`;

--- a/tests/startProject.test.ts
+++ b/tests/startProject.test.ts
@@ -1,0 +1,54 @@
+jest.mock('../src/iconize', () => ({
+  updateIcons: jest.fn(),
+}));
+
+jest.mock('obsidian', () => ({
+  App: class {},
+  TFile: class {},
+}), { virtual: true });
+
+import { startProject } from '../src/project';
+import { updateIcons } from '../src/iconize';
+
+describe('startProject', () => {
+  test('creates folder when missing', async () => {
+    const createFolder = jest.fn().mockResolvedValue(undefined);
+    const create = jest.fn().mockResolvedValue({});
+    const getAbstractFileByPath = jest
+      .fn()
+      .mockReturnValueOnce(null) // folder check
+      .mockReturnValueOnce(null); // file check
+    const openFile = jest.fn();
+    const app = {
+      vault: { getAbstractFileByPath, createFolder, create },
+      workspace: { getLeaf: jest.fn(() => ({ openFile })) },
+    } as any;
+
+    await startProject(app, 'Test', 'Projetos');
+
+    expect(createFolder).toHaveBeenCalledWith('Projetos/Test');
+    expect(create).toHaveBeenCalled();
+    expect(openFile).toHaveBeenCalled();
+    expect(updateIcons).toHaveBeenCalled();
+  });
+
+  test('ignores folder creation errors', async () => {
+    const createFolder = jest.fn().mockRejectedValue(new Error('exists'));
+    const create = jest.fn().mockResolvedValue({});
+    const getAbstractFileByPath = jest
+      .fn()
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(null);
+    const openFile = jest.fn();
+    const app = {
+      vault: { getAbstractFileByPath, createFolder, create },
+      workspace: { getLeaf: jest.fn(() => ({ openFile })) },
+    } as any;
+
+    await expect(startProject(app, 'Test', 'Projetos')).resolves.not.toThrow();
+
+    expect(createFolder).toHaveBeenCalledWith('Projetos/Test');
+    expect(create).toHaveBeenCalled();
+    expect(openFile).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `startProject` checks for the folder before creating files
- add tests for project folder creation including failure handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848f467d750832fa4ecc81a396da1e6