### PR TITLE
Improve startDay note content test

### DIFF
--- a/tests/startDay.test.ts
+++ b/tests/startDay.test.ts
@@ -101,10 +101,10 @@ describe('startDay', () => {
 
     await plugin.startDay();
 
-    expect(create).toHaveBeenCalledWith(
-      `Diario/${date}.md`,
-      expect.stringContaining(`# ${date}`)
-    );
+    const call = (create as jest.Mock).mock.calls[0];
+    expect(call[0]).toBe(`Diario/${date}.md`);
+    expect(call[1]).toContain(`# ${date}`);
+    expect(call[1]).toContain('Como você se sente hoje?');
     expect(openFile).toHaveBeenCalled();
     expect(updateIcons).toHaveBeenCalledWith(plugin.app, { Diario: 'calendar' });
     expect(showTemplatePicker).toHaveBeenCalledWith(plugin.app);


### PR DESCRIPTION
## Summary
- expand `startDay` tests to confirm the daily note text
  includes the "Como você se sente hoje?" prompt

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848f5e44b04832f89c68b8506eb6269