### PR TITLE
Add custom deck draw tests

### DIFF
--- a/tests/commandRegistration.test.ts
+++ b/tests/commandRegistration.test.ts
@@ -148,6 +148,36 @@ describe('command registration', () => {
     );
   });
 
+  test('loomnotes-draw-card uses plugin deck', async () => {
+    const replaceSelection = jest.fn();
+    const view = { editor: { replaceSelection } };
+    const customDeck = [
+      { title: 'J', description: 'K', prompt: 'L' },
+    ];
+    (drawCards as jest.Mock).mockReturnValue(customDeck);
+    const plugin = new TestPlugin({
+      workspace: { getActiveViewOfType: jest.fn(() => view) },
+    });
+    plugin.deck = customDeck as any;
+    plugin.addCommand = jest.fn();
+    plugin.registerView = jest.fn();
+    plugin.addSettingTab = jest.fn();
+    plugin.loadSettings = jest.fn();
+
+    await plugin.onload();
+
+    const call = (plugin.addCommand as jest.Mock).mock.calls.find(
+      ([cmd]) => cmd.id === 'loomnotes-draw-card'
+    );
+    expect(call).toBeDefined();
+
+    call[0].callback();
+    expect(drawCards).toHaveBeenCalledWith(1, customDeck);
+    expect(replaceSelection).toHaveBeenCalledWith(
+      '**J** - K\n_L_\n'
+    );
+  });
+
   test('loomnotes-open-reflection command invokes openReflection', async () => {
     const plugin = new TestPlugin({});
     plugin.addCommand = jest.fn();

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -13,3 +13,13 @@ test('draw card from custom deck', () => {
   const [card] = drawCards(1, custom);
   expect(custom).toContainEqual(card);
 });
+
+test('draw card from deckJSON data', () => {
+  const deck = [
+    { title: 'G', description: 'H', prompt: 'I' },
+    { title: 'J', description: 'K', prompt: 'L' },
+  ];
+  const parsed = JSON.parse(JSON.stringify(deck));
+  const [card] = drawCards(1, parsed);
+  expect(deck).toContainEqual(card);
+});


### PR DESCRIPTION
## Summary
- ensure custom decks work for `loomnotes-draw-card`
- expand oracle tests for deckJSON

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848f73f2c7c832fac08319f52ac9390