### PR TITLE
Add Templater automation and folder helpers

### DIFF
--- a/src/folders.ts
+++ b/src/folders.ts
@@ -1,0 +1,32 @@
+import { App } from 'obsidian';
+import { updateIcons } from './iconize';
+
+export async function createFolderIfMissing(app: App, path: string, icon?: string): Promise<void> {
+  if (!app.vault.getAbstractFileByPath(path)) {
+    try {
+      await app.vault.createFolder(path);
+    } catch {
+      // ignore if folder exists or cannot be created
+    }
+  }
+  if (icon) {
+    updateIcons(app, { [path]: icon });
+  }
+}
+
+export async function suggestLoomNotesFolders(app: App): Promise<void> {
+  const folders: Record<string, string> = {
+    Diario: 'calendar',
+    Reflexoes: 'pencil',
+    Projetos: 'folder',
+  };
+  for (const [folder, icon] of Object.entries(folders)) {
+    if (!app.vault.getAbstractFileByPath(folder)) {
+      if (window.confirm(`Criar pasta '${folder}'?`)) {
+        await createFolderIfMissing(app, folder, icon);
+      }
+    } else {
+      updateIcons(app, { [folder]: icon });
+    }
+  }
+}

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,29 +1,28 @@
 import { App, TFile } from 'obsidian';
 import { updateIcons } from './iconize';
+import { createFolderIfMissing } from './folders';
+import { applyTemplateToFile } from './templaterHelper';
 
-export async function startProject(app: App, name: string, baseFolder = 'Projetos'): Promise<TFile | null> {
+export async function startProject(app: App, name: string, baseFolder = 'Projetos', autoTemplate = false): Promise<TFile | null> {
   if (!name) return null;
   const folderPath = `${baseFolder}/${name}`;
-  if (!app.vault.getAbstractFileByPath(folderPath)) {
-    try {
-      await app.vault.createFolder(folderPath);
-    } catch (e) {
-      // ignore if folder exists or cannot be created
-    }
-  }
+  await createFolderIfMissing(app, folderPath);
   updateIcons(app, { [baseFolder]: 'folder', [folderPath]: 'folder' });
   const path = `${folderPath}/index.md`;
   let file = app.vault.getAbstractFileByPath(path) as TFile;
   if (!file) {
     file = await app.vault.create(path, `# ${name}\n\nDescreva o objetivo do projeto.\n`);
+    if (autoTemplate) {
+      await applyTemplateToFile(app, file);
+    }
   }
   const leaf = app.workspace.getLeaf(true);
   await leaf.openFile(file);
   return file;
 }
 
-export async function promptAndStartProject(app: App, baseFolder = 'Projetos'): Promise<TFile | null> {
+export async function promptAndStartProject(app: App, baseFolder = 'Projetos', autoTemplate = false): Promise<TFile | null> {
   const name = window.prompt('Nome do projeto');
   if (!name) return null;
-  return startProject(app, name, baseFolder);
+  return startProject(app, name, baseFolder, autoTemplate);
 }

--- a/src/reflection.ts
+++ b/src/reflection.ts
@@ -1,18 +1,17 @@
 import { App, TFile } from 'obsidian';
+import { createFolderIfMissing } from './folders';
+import { applyTemplateToFile } from './templaterHelper';
 
-export async function openReflection(app: App, folder = 'Reflexoes'): Promise<TFile> {
+export async function openReflection(app: App, folder = 'Reflexoes', autoTemplate = false): Promise<TFile> {
   const date = window.moment().format('YYYY-MM-DD');
   const path = `${folder}/${date}.md`;
-  if (!app.vault.getAbstractFileByPath(folder)) {
-    try {
-      await app.vault.createFolder(folder);
-    } catch {
-      // ignore folder creation errors
-    }
-  }
+  await createFolderIfMissing(app, folder);
   let file = app.vault.getAbstractFileByPath(path) as TFile;
   if (!file) {
     file = await app.vault.create(path, `# ${date}\n\nComo você se sente hoje?\n`);
+    if (autoTemplate) {
+      await applyTemplateToFile(app, file);
+    }
   }
   const leaf = app.workspace.getLeaf(true);
   await leaf.openFile(file);

--- a/src/templaterHelper.ts
+++ b/src/templaterHelper.ts
@@ -1,8 +1,13 @@
-import { App } from 'obsidian';
+import { App, TFile } from 'obsidian';
 
 export interface TemplaterPlugin {
   fuzzy_suggester?: {
     insert_template: () => void;
+  };
+  templater?: {
+    write_template_to_file: (template: TFile, file: TFile) => Promise<void>;
+    get_new_file_template_for_folder?: (folder: any) => string | undefined;
+    get_new_file_template_for_file?: (file: TFile) => string | undefined;
   };
 }
 
@@ -22,4 +27,22 @@ export function showTemplatePicker(app: App): boolean {
     return true;
   }
   return false;
+}
+
+export async function applyTemplateToFile(app: App, file: TFile): Promise<boolean> {
+  const plugin = getTemplaterPlugin(app) as any;
+  const templater = plugin?.templater;
+  if (!templater?.write_template_to_file) return false;
+  const match =
+    templater.get_new_file_template_for_folder?.(file.parent) ||
+    templater.get_new_file_template_for_file?.(file);
+  if (!match) return false;
+  const tplFile = app.vault.getAbstractFileByPath(match) as TFile;
+  if (!tplFile) return false;
+  try {
+    await templater.write_template_to_file(tplFile, file);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/tests/commandRegistration.test.ts
+++ b/tests/commandRegistration.test.ts
@@ -69,6 +69,7 @@ describe('command registration', () => {
     plugin.registerView = jest.fn();
     plugin.addSettingTab = jest.fn();
     plugin.loadSettings = jest.fn();
+    plugin.settings = { autoTemplates: false, autoFolders: false } as any;
 
     await plugin.onload();
 
@@ -88,6 +89,7 @@ describe('command registration', () => {
     plugin.registerView = jest.fn();
     plugin.addSettingTab = jest.fn();
     plugin.loadSettings = jest.fn();
+    plugin.settings = { autoTemplates: false, autoFolders: false } as any;
 
     await plugin.onload();
 
@@ -108,6 +110,7 @@ describe('command registration', () => {
     plugin.registerView = jest.fn();
     plugin.addSettingTab = jest.fn();
     plugin.loadSettings = jest.fn();
+    plugin.settings = { autoTemplates: false, autoFolders: false } as any;
 
     await plugin.onload();
 
@@ -134,6 +137,7 @@ describe('command registration', () => {
     plugin.registerView = jest.fn();
     plugin.addSettingTab = jest.fn();
     plugin.loadSettings = jest.fn();
+    plugin.settings = { autoTemplates: false, autoFolders: false } as any;
 
     await plugin.onload();
 
@@ -163,6 +167,7 @@ describe('command registration', () => {
     plugin.registerView = jest.fn();
     plugin.addSettingTab = jest.fn();
     plugin.loadSettings = jest.fn();
+    plugin.settings = { autoTemplates: false, autoFolders: false } as any;
 
     await plugin.onload();
 
@@ -184,6 +189,7 @@ describe('command registration', () => {
     plugin.registerView = jest.fn();
     plugin.addSettingTab = jest.fn();
     plugin.loadSettings = jest.fn();
+    plugin.settings = { autoTemplates: false, autoFolders: false } as any;
 
     await plugin.onload();
 
@@ -193,7 +199,11 @@ describe('command registration', () => {
     expect(call).toBeDefined();
 
     call[0].callback();
-    expect(openReflection).toHaveBeenCalledWith(plugin.app);
+    expect(openReflection).toHaveBeenCalledWith(
+      plugin.app,
+      'Reflexoes',
+      plugin.settings.autoTemplates
+    );
   });
 
   test('loomnotes-start-project command invokes promptAndStartProject', async () => {
@@ -202,6 +212,7 @@ describe('command registration', () => {
     plugin.registerView = jest.fn();
     plugin.addSettingTab = jest.fn();
     plugin.loadSettings = jest.fn();
+    plugin.settings = { autoTemplates: false, autoFolders: false } as any;
 
     await plugin.onload();
 
@@ -211,6 +222,10 @@ describe('command registration', () => {
     expect(call).toBeDefined();
 
     call[0].callback();
-    expect(promptAndStartProject).toHaveBeenCalledWith(plugin.app);
+    expect(promptAndStartProject).toHaveBeenCalledWith(
+      plugin.app,
+      'Projetos',
+      plugin.settings.autoTemplates
+    );
   });
 });

--- a/tests/startDay.test.ts
+++ b/tests/startDay.test.ts
@@ -1,6 +1,6 @@
 import { LumiModal } from '../src/lumiModal';
 import { updateIcons } from '../src/iconize';
-import { isTemplaterEnabled, showTemplatePicker } from '../src/templaterHelper';
+import { isTemplaterEnabled, showTemplatePicker, applyTemplateToFile } from '../src/templaterHelper';
 
 jest.mock('../src/lumiModal', () => ({
   __esModule: true,
@@ -14,6 +14,7 @@ jest.mock('../src/iconize', () => ({
 jest.mock('../src/templaterHelper', () => ({
   isTemplaterEnabled: jest.fn(),
   showTemplatePicker: jest.fn(),
+  applyTemplateToFile: jest.fn(),
 }));
 
 jest.mock('obsidian', () => ({
@@ -59,7 +60,7 @@ describe('startDay', () => {
       vault: { getAbstractFileByPath, createFolder, create },
       workspace: { getLeaf: jest.fn(() => leaf) },
     });
-    plugin.settings = { dailyFolder: 'Diario', deckJSON: '' } as any;
+    plugin.settings = { dailyFolder: 'Diario', deckJSON: '', autoTemplates: false } as any;
 
     await plugin.startDay();
 
@@ -78,7 +79,7 @@ describe('startDay', () => {
       vault: { getAbstractFileByPath, createFolder, create },
       workspace: { getLeaf: jest.fn(() => leaf) },
     });
-    plugin.settings = { dailyFolder: 'Diario', deckJSON: '' } as any;
+    plugin.settings = { dailyFolder: 'Diario', deckJSON: '', autoTemplates: false } as any;
 
     await expect(plugin.startDay()).resolves.not.toThrow();
     expect(create).toHaveBeenCalled();
@@ -97,7 +98,7 @@ describe('startDay', () => {
       vault: { getAbstractFileByPath, createFolder, create },
       workspace: { getLeaf: jest.fn(() => ({ openFile })) },
     });
-    plugin.settings = { dailyFolder: 'Diario', deckJSON: '' } as any;
+    plugin.settings = { dailyFolder: 'Diario', deckJSON: '', autoTemplates: true } as any;
 
     await plugin.startDay();
 
@@ -107,7 +108,8 @@ describe('startDay', () => {
     expect(call[1]).toContain('Como você se sente hoje?');
     expect(openFile).toHaveBeenCalled();
     expect(updateIcons).toHaveBeenCalledWith(plugin.app, { Diario: 'calendar' });
-    expect(showTemplatePicker).toHaveBeenCalledWith(plugin.app);
+    expect(applyTemplateToFile).toHaveBeenCalledWith(plugin.app, expect.anything());
+    expect(showTemplatePicker).not.toHaveBeenCalled();
     const modal = (LumiModal as jest.Mock).mock.results[0].value;
     expect(modal.open).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- integrate Templater with automatic template application
- add folder creation helpers and optional default folders
- expose settings to control templater and folder automation
- adjust commands and unit tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848fc8ccef8832fa9101d8437142ba6